### PR TITLE
fix(companion): place island on active screen in multi-monitor setups

### DIFF
--- a/pi-extension/companion.mjs
+++ b/pi-extension/companion.mjs
@@ -27,17 +27,34 @@ import { buildIslandHTML } from "./island.html.mjs";
 import { SOCK } from "./socket-path.mjs";
 
 // ---- Screen geometry ------------------------------------------------------
-// Same JXA probe used by earlier single-window mode. We target NSScreen.
-// screens[0] (the primary / menu-bar screen) so the window stays put when
-// focus moves between displays.
+// Find the screen to host the island on. Strategy:
+//   1. Screen under the mouse cursor (what the user is looking at right now).
+//   2. NSScreen.mainScreen  (menu-bar / focused screen).
+//   3. NSScreen.screens[0]  (last-resort, documented as arbitrary order).
+//
+// We return the screen's *global* origin in addition to its size, so the
+// caller can place the window in the global coordinate space instead of
+// accidentally using screen-local coords as global ones (which lands the
+// window in a random spot on multi-monitor setups).
 function getScreenGeometry() {
   try {
     const script =
       "ObjC.import('AppKit');" +
-      "const s = $.NSScreen.screens.js[0];" +
+      "const mouse = $.NSEvent.mouseLocation;" +
+      "const all = $.NSScreen.screens.js;" +
+      "let s = null;" +
+      "for (const scr of all) {" +
+      "  const f = scr.frame;" +
+      "  if (mouse.x >= f.origin.x && mouse.x < f.origin.x + f.size.width &&" +
+      "      mouse.y >= f.origin.y && mouse.y < f.origin.y + f.size.height) {" +
+      "    s = scr; break;" +
+      "  }" +
+      "}" +
+      "if (!s) s = $.NSScreen.mainScreen;" +
+      "if (!s || !s.frame) s = all[0];" +
       "const f = s.frame;" +
       "const sa = (s.safeAreaInsets && s.safeAreaInsets.top) || 0;" +
-      "JSON.stringify({w: f.size.width, h: f.size.height, notch: sa})";
+      "JSON.stringify({x: f.origin.x, y: f.origin.y, w: f.size.width, h: f.size.height, notch: sa})";
     const out = execSync(`osascript -l JavaScript -e ${JSON.stringify(script)}`, {
       encoding: "utf8",
       timeout: 1500,
@@ -45,13 +62,15 @@ function getScreenGeometry() {
     const j = JSON.parse(out);
     if (Number.isFinite(j.w) && Number.isFinite(j.h)) {
       return {
+        x:      Math.round(j.x || 0),
+        y:      Math.round(j.y || 0),
         width:  Math.round(j.w),
         height: Math.round(j.h),
         notch:  Math.round(j.notch || 0),
       };
     }
   } catch { /* fall through */ }
-  return { width: 1440, height: 900, notch: 0 };
+  return { x: 0, y: 0, width: 1440, height: 900, notch: 0 };
 }
 
 // ---- Window setup ---------------------------------------------------------
@@ -61,9 +80,18 @@ function getScreenGeometry() {
 const WIN_W = 640;
 const WIN_H = 420; // room for ~10 rows comfortably
 
-const { width: screenW, height: screenH, notch: notchH } = getScreenGeometry();
-const x = Math.max(0, Math.round((screenW - WIN_W) / 2));
-const y = Math.max(0, screenH - WIN_H);
+const {
+  x: screenX,
+  y: screenY,
+  width:  screenW,
+  height: screenH,
+  notch:  notchH,
+} = getScreenGeometry();
+
+// Place the window top-center of the *active* screen, in the global
+// coordinate space (macOS uses bottom-left origin; larger y = further up).
+const x = Math.round(screenX + (screenW - WIN_W) / 2);
+const y = Math.round(screenY + screenH - WIN_H);
 
 const autoMode = notchH > 0 ? "notch" : "normal";
 


### PR DESCRIPTION
## What

Fixes the island landing at a random position on multi-monitor setups (closes #2).

## Root cause

`pi-extension/companion.mjs` picked the screen via `NSScreen.screens[0]`, which Apple documents as having **arbitrary order** — on multi-monitor setups it is **not** guaranteed to be the primary / menu-bar screen. Worse, it then computed the window origin using only the screen's `size`:

```js
const x = Math.round((screenW - WIN_W) / 2);
const y = screenH - WIN_H;
```

These coordinates are then passed to the Swift host, which interprets them in the **global** macOS coordinate space (origin bottom-left, spanning all displays). If `screens[0]` happened to be a non-primary display (e.g. a MacBook's built-in panel sitting at `origin.y = -956` below an external monitor at `(0, 0)`), the screen-local (x, y) landed at a essentially random global coordinate — often somewhere in the middle of another monitor.

### Confirmed with a real two-monitor setup

```json
{
  "screens": [
    { "index": 0, "x": 0,   "y": 0,    "w": 2560, "h": 1440, "notch": 0  },  // external
    { "index": 1, "x": 506, "y": -956, "w": 1470, "h": 956,  "notch": 32 }   // MacBook
  ]
}
```

If `screens[0]` had instead returned the MacBook, the old code produced `(415, 536)` — which in global coordinates lands in the **middle-left of the external monitor**. Exactly the reported symptom.

## Fix

`getScreenGeometry()` now:

1. Prefers the screen **under the mouse cursor** (the screen the user is looking at).
2. Falls back to `NSScreen.mainScreen` (menu-bar / focused screen).
3. Falls back to `screens[0]` only as a last resort.

It also returns `frame.origin.x / frame.origin.y`, which the caller adds when computing the top-center placement so the window lands at the top of the **active** display regardless of the display arrangement:

```js
const x = Math.round(screenX + (screenW - WIN_W) / 2);
const y = Math.round(screenY + screenH - WIN_H);
```

## Test

Verified on a dual-monitor setup (MacBook M4 + external 2560×1440). Before: island appeared at a random spot on the external monitor. After: island sits at the top-center of whichever display the cursor is on.

Closes #2