### PR TITLE
feat(island): v0.2.0 — settings menu, size/screen/notch prefs, overlap fix

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -86,7 +86,7 @@ Three processes, three protocols:
    `open-fixed.mjs` (see §7: host binary protocol).
 3. **companion → WebView JS** — `win.send(js)` calls `evaluateJavaScript`
    inside the Swift host. The JS exposes `window.island.{upsertRow,
-   removeRow, setMode}` (see `island.html.mjs`).
+   removeRow, setMode, setScale}` (see `island.html.mjs`).
 
 Inside the WebView, a single 80 ms braille ticker and a single 250 ms
 elapsed ticker update all rows in sync. Rows are merged via
@@ -145,31 +145,55 @@ README color table.
 
 - Context: `ctx.getContextUsage()?.percent`, rounded. Shown as `34%`.
   Color gates: ≥60 → amber, ≥85 → red.
-- Timer: `(Date.now() - startedAt) / 1000`, formatted `1.2s / 42s /
-  1m 47s / 2h 15m`. Note the space between `1m` and `47s` — user-
-  requested readability fix, don't collapse.
+- Timer: `(Date.now() - startedAt) / 1000`, formatted as integer
+  seconds — `0s / 42s / 16m / 16m 52s / 2h 15m`. Note the space
+  between `1m` and `47s` — user-requested readability fix, don't
+  collapse. The "sub" unit (` 52s` after `16m`, ` 15m` after `2h`) is
+  a separate span so notch mode can `display:none` it independently
+  — in the notched first row the readout stays at 3–4 chars (`16m`,
+  `1h`, `12h`) so the growing timer never slides behind the notch.
 
-### 4.5. The `/island` vs `/island2` commands
+### 4.5. The `/island` command (v0.2.0+)
 
-Both commands are registered in `index.ts` via `pi.registerCommand`.
-Since **v0.1.1** the island is ON by default — user preference is
-persisted in `~/.pi/pi-island.json` (`{"enabled": true|false}`) and
-read on extension load. `/island` flips + writes the new value, so the
-choice survives every pi restart until explicitly toggled again.
+`/island` is the single entry point — no more `/island2`. With no args it
+opens a settings menu rendered via `ctx.ui.custom()` + pi-tui's
+`SettingsList` (the same drop-down UX as pi's own `/settings`). Four
+rows, each Enter/Space cycles its values:
 
-| Command     | Effect                                                                                            |
-|-------------|---------------------------------------------------------------------------------------------------|
-| `/island`   | Toggle visibility AND persist to `~/.pi/pi-island.json`. Off → row retracts, no updates sent. On → capsule appears on next agent turn. |
-| `/island2`  | Force `shownForSession = true`, persist enabled, AND send `{type:"mode", mode:"notch"}` to the companion. |
+| Setting      | Values                               | Apply method                           |
+|--------------|--------------------------------------|----------------------------------------|
+| Visibility   | `enabled` / `disabled`               | Live (send remove / ensureConnection). |
+| Size         | `small` / `medium` / `large` / `xlarge` | Live (socket `scale` message).      |
+| Screen       | `primary` / `active` / `2` / `3` …  | Respawn companion (NSWindow fixed).    |
+| Notch wrap   | `auto` / `normal` / `notch`          | Respawn companion (read at spawn).     |
 
-**Known limitation:** there is no `/island3` or "go back to normal
-mode" toggle. If you hit `/island2` on a non-notched Mac and want
-the middle content back, you have to kill the companion
-(`pkill -f companion.mjs`) and `/island` again. Tracked in §11.
+All four fields are persisted in `~/.pi/pi-island.json`:
+```json
+{ "enabled": true, "scale": "medium", "screen": "primary", "notchMode": "auto" }
+```
+Missing fields fall back to defaults, so a v0.1.x pref file (just
+`{"enabled": true}`) upgrades cleanly with no user action.
 
-The companion ALSO auto-detects the notch on spawn via JXA
-`safeAreaInsets.top`. So on a MacBook with a notch, you get notch mode
-automatically without typing `/island2`.
+**Quick-action subcommands** (skip the menu — same helpers, same persistence):
+```
+/island on | enable | off | disable | toggle
+/island size   <small|medium|large|xlarge>
+/island screen <primary|active|2|3|...>
+/island notch  <auto|normal|notch>
+```
+
+**Removed in v0.2.0:** `/island2`. Its behaviour (force notch wrap)
+moved into the menu's `Notch wrap` row — and unlike the old command,
+there is now an `auto` value to revert to detection mode. Release notes
+flagged this as a breaking change.
+
+The companion still auto-detects the notch on spawn via JXA
+`safeAreaInsets.top` whenever `notchMode` resolves to `auto`.
+
+**See also:** helpers live in `index.ts` — `doEnable/doDisable/
+doSetScale/doSetScreen/doSetNotchMode`, `openSettingsMenu`,
+`respawnCompanion`. Menu and subcommands share the same helpers so
+behaviour can't drift.
 
 ---
 
@@ -182,20 +206,29 @@ One JSON object per line. Writer: `writeMessage` in `index.ts`. Reader:
 // Client → companion, normal update (most common)
 { "id":             "<8-char-uuid>",   // stable per pi session (randomUUID().slice(0,8))
   "type":           "update",
-  "project":        "pi-auth",         // basename(cwd)
+  "project":        "pi-auth",         // basename(cwd), truncated to ≤20 chars
   "status":         "editing",         // see STATUS table in island.html.mjs
   "detail":         "login.ts",        // optional, tool-specific short string
   "prompt":         "fix the auth…",   // already truncated to ≤48 chars
   "ctxPct":         34,                // 0-100, null if unknown
   "startedAt":      1713622000000,     // ms epoch, set on agent_start
-  "frozenElapsed":  null               // non-null ms = stop ticking timer
+  "frozenElapsed":  null,              // non-null ms = stop ticking timer
+  "rowScale":       "large"            // optional, DEMO-ONLY per-row scale override
 }
 
 // Remove a row (pi session retracted or shut down)
 { "id": "...", "type": "remove" }
 
-// Force notch mode on the WebView
-{ "id": "...", "type": "mode", "mode": "normal" | "notch" }
+// Notch mode — flips body.notch-mode class in the WebView (live, no respawn)
+{ "id": "...", "type": "mode",    "mode":  "normal" | "notch" }
+
+// Size preset — flips the global --scale CSS var (live, no respawn)
+{ "id": "...", "type": "scale",   "scale": "small" | "medium" | "large" | "xlarge" }
+
+// Graceful companion shutdown — client's next ensureConnection() spawns a
+// fresh instance that re-reads ~/.pi/pi-island.json (used for screen and
+// notchMode changes where NSWindow geometry is fixed at spawn).
+{ "id": "...", "type": "respawn" }
 ```
 
 **Required vs optional:**
@@ -214,14 +247,33 @@ thinking | reading | editing | writing | running | searching | done | error
 
 Unknown statuses fall back to `thinking` visual.
 
+**Preference schema** (`~/.pi/pi-island.json`) — owned by `index.ts`,
+but also read directly by `companion.mjs` on spawn for `screen` and
+`notchMode` (settings that determine NSWindow geometry and can't be
+changed without a fresh window). All fields are optional; missing
+values fall back to defaults.
+```jsonc
+{
+  "enabled":   true,          // default true
+  "scale":     "medium",      // default "medium"  (one of SCALES in §12)
+  "screen":    "primary",     // default "primary" | "active" | "2" | "3" | …
+  "notchMode": "auto"         // default "auto"    | "normal" | "notch"
+}
+```
+
 ---
 
 ## 6. Key design decisions (don't undo these)
 
-### 6.1. Pin to `NSScreen.screens[0]` — the menu-bar screen
-`mainScreen` follows the focused window; it caused the capsule to jump
-displays when the user dragged focus. Geometry is re-probed via JXA on
-every companion spawn so arrangement changes are picked up live.
+### 6.1. Screen selection is a user preference (v0.2.0+)
+Default is `NSScreen.screens[0]` (menu-bar screen, `"primary"`) — the
+original stable anchor that avoided the "capsule jumps with focus" bug
+that `mainScreen` caused. But users on multi-monitor setups can opt in
+to `"active"` (screen under mouse at spawn, the PR #3 behaviour) or a
+specific monitor index (`"2"`, `"3"` …). The selector runs in JXA inside
+`companion.mjs::buildScreenSelectorJXA()`. Geometry is re-probed on
+every companion spawn; changing the `screen` pref sends a `respawn`
+message so the change is immediate.
 
 ### 6.2. Window level = `.statusBar` + `constrainFrameRect` override
 Two lines inside `island-host.swift` that make Dynamic-Island
@@ -249,35 +301,53 @@ Consecutive rows share a 1 px `rgba(255,255,255,0.08)` divider; only the
 last row rounds its bottom corners. No per-row drop-shadow (shadow
 bled into the screen edge as a visible black corner).
 
-### 6.5. Notch mode — auto on spawn, manual override via `/island2`
-`companion.mjs` sets `autoMode = notchH > 0 ? "notch" : "normal"` based
-on JXA `safeAreaInsets.top` and applies it when the WebView signals
-`ready`. `/island2` overrides to `"notch"` on demand (no reverse
-command exists — see §11).
+### 6.5. Notch mode — pref-driven with an `auto` default (v0.2.0+)
+`companion.mjs` reads `notchMode` from the pref file on spawn and
+decides:
+- `auto` (default) — `autoMode = notchH > 0 ? "notch" : "normal"`, the
+  original behaviour via JXA `safeAreaInsets.top`.
+- `normal` — force disabled regardless of detection.
+- `notch` — force enabled regardless of detection (replaces the old
+  `/island2` command).
+
+The live `{type:"mode"}` socket message still exists for same-session
+toggles, but settings-menu changes to `notchMode` round-trip through
+`respawn` so `autoMode` is recomputed with the new pref.
 
 ### 6.6. Demo matches production sizing
 `demo.mjs` routes through the **same** companion / WebView as real pi,
 so row size is intrinsically identical. Do not re-introduce a
 standalone demo HTML — it drifts.
 
-### 6.7. Sizing constants (all live in `companion.mjs` + `island.html.mjs`)
+### 6.7. Sizing constants
 
-| Constant              | Value       | Where / why                                                    |
-|-----------------------|-------------|----------------------------------------------------------------|
-| `WIN_W`               | 640 px      | `companion.mjs` — outer WebView window width (wider than the capsule itself so we have breathing room; the extra is transparent + clickThrough). |
-| `WIN_H`               | 420 px      | `companion.mjs` — window height, room for ~10 stacked rows. NSWindow can't be resized after spawn so we reserve. |
-| Window position       | `x = (screenW-WIN_W)/2, y = screenH-WIN_H` | Center horizontally; Cocoa origin is bottom-left, so `screenH-WIN_H` puts the TOP of the window at the TOP of the screen. |
-| Row width             | 460 px      | `island.html.mjs .row` — chosen by eye to match iPhone Dynamic Island proportions. |
-| Row height            | 34 px       | `island.html.mjs .row` — same. Animated via `max-height` for fade-in. |
-| Row grid (left/mid/right) | auto / 150 px max / auto | Flex layout with middle absolute-centered; 150 px middle keeps clear of left (~130 content) + right (~170 content). |
-| JXA fallback geometry | `1440×900, notch=0` | If the osascript probe fails (should never). |
-| JXA probe timeout     | 1500 ms     | `getScreenGeometry()` in `companion.mjs`. |
-| Idle-exit delay       | 6000 ms     | `scheduleIdleExit()` in `companion.mjs`. |
-| Done-row retract      | 5000 ms     | `hideTimer` in `index.ts` after `agent_end`. |
-| Error auto-revert     | 1500 ms     | `tool_execution_end` error branch in `index.ts`. |
-| Braille tick          | 80 ms       | `tickerB` in `island.html.mjs`. |
-| Elapsed tick          | 250 ms      | `tickerT` in `island.html.mjs`. |
-| Prompt truncation     | 48 chars    | `truncatePrompt()` in `index.ts`. |
+All numeric sizes in `island.html.mjs` that affect visual proportion are
+multiplied by `var(--scale)`, a CSS custom property driven by the user's
+`size` preset. Defaults below are at `medium` (`--scale: 1.0`).
+`setScale(name)` on `window.island` flips the global scale; demo mode
+can also set `--scale` inline on a single row via `rowScale` for the
+"all presets stacked" showcase.
+
+| Constant              | Value @ medium | Notes                                                       |
+|-----------------------|----------------|-------------------------------------------------------------|
+| `WIN_W`               | 640 px (fixed) | `companion.mjs`. Must fit the largest row (621 px at xlarge) plus clickThrough breathing room. |
+| `WIN_H`               | 420 px (fixed) | `companion.mjs`. NSWindow can't be resized after spawn so we reserve room for ~9-10 stacked rows at any scale. |
+| Window position       | `x = (screenW-WIN_W)/2, y = screenH-WIN_H` | Global coords; `y` places the TOP of the window at the TOP of the chosen screen. |
+| `SCALES` (JS)         | `{small:0.88, medium:1.0, large:1.18, xlarge:1.35}` | `island.html.mjs`. Must match the `SCALES` string list in `index.ts`. 1.35 is the ceiling at `WIN_W=640`. |
+| Row width             | `460 * scale`  | `.row` width — scales so left/middle/right proportions stay balanced. |
+| Row height            | `34 * scale`   | `.row` height; `max-height` enter animation uses the same calc. |
+| Left slot max-width   | `130 * scale`  | `.slot.left` clamps the project name via ellipsis so long basenames don't collide with the absolute-centered middle slot. |
+| Middle slot max-width | `150 * scale`  | `.slot.mid`, absolute-centered. |
+| Border radius (bottom corners of last row) | `22 * scale` | Capsule corner rounding. |
+| JXA fallback geometry | `1440×900, notch=0` | If the osascript probe fails (should never).       |
+| JXA probe timeout     | 1500 ms        | `getScreenGeometry()` in `companion.mjs`.                   |
+| Idle-exit delay       | 6000 ms        | `scheduleIdleExit()` in `companion.mjs`.                    |
+| Done-row retract      | 5000 ms        | `hideTimer` in `index.ts` after `agent_end`.                |
+| Error auto-revert     | 1500 ms        | `tool_execution_end` error branch in `index.ts`.            |
+| Braille tick          | 80 ms          | `tickerB` in `island.html.mjs`.                             |
+| Elapsed tick          | 250 ms         | `tickerT` in `island.html.mjs`. Timer shows integer seconds. |
+| Prompt truncation     | 48 chars       | `truncatePrompt()` in `index.ts`.                           |
+| Project truncation    | 20 chars       | `truncateProject()` in `index.ts` (source-side guard; CSS ellipsis adds a second safety net). |
 
 ---
 
@@ -337,21 +407,35 @@ back (e.g. click-to-dismiss).
 ## 8. What is done
 
 - ✅ Window pinned top-of-screen above menu bar (all Macs)
-- ✅ Notch wrap via `/island2` + auto-detect on spawn
-- ✅ Compact fixed size (no resize on state change)
+- ✅ Compact fixed-size window (no resize on state change)
 - ✅ Dot-loader + per-status colors (matches pi's own loader set)
-- ✅ Context % + elapsed timer (tabular-nums; space between `1m` and `47s`)
-- ✅ Multi-monitor: always targets menu-bar screen
+- ✅ Context % + elapsed timer (integer seconds, abbreviated in notch mode)
 - ✅ Multi-session stack (rows fuse into one capsule, shared dividers)
 - ✅ Demo mirrors real runtime dimensions
 - ✅ Middle slot is pixel-stable (absolute centered)
 - ✅ Auto idle-exit of companion 6 s after last client disconnects
 - ✅ GitHub Actions auto-publish on `v*` tag push
 - ✅ Default-on with persisted user preference (v0.1.1)
+- ✅ Settings menu via `ctx.ui.custom()` + pi-tui `SettingsList` (v0.2.0)
+- ✅ Size presets — `small`/`medium`/`large`/`xlarge` via `--scale` CSS var (v0.2.0)
+- ✅ Screen preference — `primary`/`active`/numeric index (v0.2.0)
+- ✅ Notch mode preference — `auto`/`normal`/`notch` (replaces `/island2`) (v0.2.0)
+- ✅ Project name overlap fix (issue #4) — source-side truncation + CSS ellipsis (v0.2.0)
+- ✅ Quick-action subcommands: `/island size|screen|notch|on|off|toggle` (v0.2.0)
+- ✅ Per-row `rowScale` demo hook for "all presets stacked" showcase (v0.2.0)
 
 ---
 
 ## 9. Release process
+
+> **Day-to-day dev/release workflow lives in [`docs/RELEASING.md`](docs/RELEASING.md).**
+> It documents the three loops (`dev:link` → `pack:test` → `release:*`)
+> and is the single source of truth once the project has been published.
+>
+> The subsections below (§9.1 – §9.7) describe the **one-off v0.1.0
+> initial publish setup** (`NPM_TOKEN`, GitHub Actions workflow, first
+> tarball). They are kept for historical reference. Don't follow them
+> for routine releases — use `docs/RELEASING.md`.
 
 Target: publishable open-source npm package installable via
 `pi install npm:pi-island`.
@@ -423,33 +507,43 @@ The workflow runs `npm publish --access public` on `macos-latest` with
 
 ## 10. Developer workflow
 
-Three ways to iterate, ranked by inner-loop speed:
+Three loops, ranked by inner-loop speed. Full walkthrough in
+[`docs/RELEASING.md`](docs/RELEASING.md).
 
 ### 10.1. Fastest — demo only
 ```bash
-node pi-extension/demo.mjs          # stacked demo
-node pi-extension/demo.mjs single   # single-row cycle
+node pi-extension/demo.mjs           # stacked demo (default)
+node pi-extension/demo.mjs single    # single-row walkthrough
+node pi-extension/demo.mjs overlap   # long project name + long prompt regression test
+node pi-extension/demo.mjs long      # 1000s task, ticks forever (Ctrl+C)
+node pi-extension/demo.mjs sizes     # all four size presets stacked
 ```
-No pi involved. Edit `island.html.mjs` / `companion.mjs` then re-run.
-If the companion was running, kill it first:
-```bash
-pkill -f pi-island/pi-extension/companion.mjs
-```
+No pi involved. Any of those accept an optional scale argument
+(`node pi-extension/demo.mjs single large`). Edit `island.html.mjs` /
+`companion.mjs`, `pkill -f pi-island/pi-extension/companion.mjs`, re-run.
 
-### 10.2. Medium — pi with local path install
+### 10.2. Medium — `npm link`ed pi (loop 1 in RELEASING.md)
 ```bash
-pi install /absolute/path/to/pi-island
+npm run dev:link     # global pi-island → symlinks to this repo
+npm run dev:status   # confirm LINKED vs NPM mode before a release
 ```
-Inside pi:
-- `/reload` picks up `index.ts` changes without restarting pi.
-- `/island` toggles the capsule.
-- Changes to Swift or the companion STILL require `pkill` + next run.
+`index.ts` edits go live via pi's `/reload`. Swift + companion changes
+still need `pkill` + next invocation so the daemon respawns.
 
-### 10.3. Slow — real npm install
+### 10.3. Pre-publish — real tarball (loop 2)
 ```bash
-pi install npm:pi-island
+npm run pack:test    # unlinks dev symlink, runs npm pack, installs tarball
 ```
-Only useful for smoke-testing the published tarball. Don't iterate here.
+Now `pi` runs the exact bits npm will ship. Test every menu row, scale,
+screen, notch mode, and the demo scripts here before publishing.
+
+### 10.4. Release (loop 3)
+```bash
+npm run release:patch   # bug fixes
+npm run release:minor   # new features (pre-1.0 may include breaking)
+npm run release:major   # breaking changes, post-1.0
+```
+Then `npm run dev:link` again to resume development.
 
 ---
 
@@ -531,6 +625,15 @@ caused confusing "why is the old binary running?" sessions.
   2. `renderRowContent` in `island.html.mjs`
   3. §5 of this file (socket contract)
 - Keep `AGENT.md` §6.7 (sizing table) in sync with any constant change.
+- When adding a **size preset**, update THREE places:
+  1. `SCALES` string array in `index.ts` (menu + subcommand validation).
+  2. `SCALES` number map in `island.html.mjs` (actual CSS scale).
+  3. §6.7 sizing table in this file.
+- When adding a **new preference field**, update FOUR places:
+  1. `Preference` type + `readPreference()` + `writePreference()` in `index.ts`.
+  2. `persistPref()` / helpers that call `writePreference`.
+  3. Settings menu row in `openSettingsMenu()` if user-configurable.
+  4. §5 pref schema in this file.
 - Turkish user comms are fine; code / commits / docs stay English.
 
 ---
@@ -549,31 +652,35 @@ caused confusing "why is the old binary running?" sessions.
 
 ## 14. Known limitations / quirks
 
-- **`/island2` has no toggle-back** — once you switch to notch mode,
-  there's no command to return to normal mode without killing the
-  companion. Fix: add `/island3` or make `/island2` toggle.
+- **Screen / notch change requires a respawn** — NSWindow geometry is
+  fixed at spawn. `doSetScreen` / `doSetNotchMode` send `{type:"respawn"}`
+  and the client's next `ensureConnection()` starts a fresh companion.
+  The ~300 ms gap is visible as a brief capsule disappearance.
 - **Single socket carries multiple session IDs** — when one pi process
   sends removes for id A then id B on the same socket, the companion's
   `sock.on("close")` only knows the *last* clientId. If the socket
   dies mid-stream, stale rows can remain until idle-exit fires. Low
   impact; fix by tracking all ids seen on a given socket.
 - **Resizing not supported** — `NSWindow` after spawn cannot change
-  size. If we ever need dynamic sizing, `island-host.swift` needs a
-  `{type:"resize"}` stdin handler.
-- **Peer dependency is `"*"`** — `@mariozechner/pi-coding-agent` pinned
-  to any version. If the extension API changes, install may succeed
-  but `index.ts` will crash on load. Pin when pi reaches 1.0.
+  size. Size preset changes flip a CSS var live (no respawn needed)
+  because `WIN_W`/`WIN_H` are reserved big enough for `xlarge`. A
+  future `xxlarge` would need a `{type:"resize"}` handler in
+  `island-host.swift` or a `WIN_W` bump.
+- **Peer dependencies are `"*"`** — `@mariozechner/pi-coding-agent`
+  and `@mariozechner/pi-tui` are both pinned to any version. If either
+  API changes, install may succeed but the extension crashes on load.
+  Pin when pi reaches 1.0.
 - **No uninstall cleanup hook** — `npm uninstall` / `pi uninstall`
-  leaves `~/.pi/pi-island.sock` if the companion was killed mid-run.
-  Harmless on next run (auto-unlinked).
+  leaves `~/.pi/pi-island.sock` and `~/.pi/pi-island.json` if the
+  companion was killed mid-run. Harmless on next run (sock auto-
+  unlinks, pref file is idempotent).
 
 ---
 
 ## 15. Future improvement backlog
 
-Not planned for v0.1.0 but worth tracking:
+Not planned yet but worth tracking:
 
-- `/island3` command to revert notch → normal at runtime.
 - Expand/collapse animation on hover (hover is currently blocked by
   `clickThrough: true`; would need mouse-tracking area).
 - Show the tool's actual target in `detail` for `bash` (current first

--- a/README.md
+++ b/README.md
@@ -17,18 +17,44 @@ Requires **macOS** + **pi** + Xcode Command Line Tools
 pi install npm:pi-island
 ```
 
-## Use
+The island turns on automatically for every pi session after install.
+Type `/island` any time to tweak it.
 
-Inside any pi session:
+## Settings
+
+Inside any pi session, type:
 
 ```
-/island     toggle the capsule on/off
-/island2    notch-wrap variant (for MacBooks with a notch)
+/island
+```
+
+A drop-down opens with four rows. Cycle each value with Enter or Space:
+
+| Setting       | Values                              | Notes                                          |
+|---------------|-------------------------------------|------------------------------------------------|
+| Visibility    | `enabled` / `disabled`              | Remember the choice across restarts.           |
+| Size          | `small` / `medium` / `large` / `xlarge` | Live — no respawn.                         |
+| Screen        | `primary` / `active` / `2` / `3` …  | `primary` = menu-bar display, `active` = under mouse, numbers for multi-monitor. |
+| Notch wrap    | `auto` / `normal` / `notch`         | `auto` detects. Forcing off/on also supported. |
+
+Your choices are persisted in `~/.pi/pi-island.json` and survive
+every pi restart.
+
+### Quick-actions (skip the menu)
+
+Muscle memory / scripts:
+
+```
+/island on            # or: enable
+/island off           # or: disable
+/island toggle
+/island size large
+/island screen primary
+/island notch notch
 ```
 
 Run pi in multiple terminals — each session gets its own row,
 stacked into one continuous capsule.
-
 
 ## Website
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,9 +72,19 @@ This:
 Now `pi` is running the **future npm package**. Test the real flows:
 
 ```bash
-pi /island
-node pi-extension/demo.mjs
+pi /island                             # settings menu opens, 4 rows cycle cleanly
+pi /island size large                  # quick-action applies live
+node pi-extension/demo.mjs sizes       # all four presets stacked visually
+node pi-extension/demo.mjs long        # long-running task, timer ticks
 ```
+
+Also spot-check:
+
+- Every row in the menu cycles its values on Enter/Space.
+- Screen change respawns the companion and the capsule reappears on the
+  picked display.
+- Notch wrap `auto` / `normal` / `notch` respawns and re-detects.
+- Pref file `~/.pi/pi-island.json` now contains all four fields.
 
 If something is broken here that wasn't broken in loop 1, it's almost
 always one of:
@@ -83,6 +93,7 @@ always one of:
 - `scripts/postinstall.mjs` crashed on a clean install.
 - A path that worked because of the symlink is actually wrong in a
   normal install layout.
+- A new peer dependency is missing from `package.json`’s `peerDependencies`.
 
 Fix, commit, merge, re-run `npm run pack:test`.
 
@@ -94,9 +105,14 @@ When `pack:test` is green, release with one command:
 
 ```bash
 npm run release:patch      # 0.1.2 → 0.1.3   (bug fixes)
-npm run release:minor      # 0.1.2 → 0.2.0   (new features, backwards compatible)
-npm run release:major      # 0.1.2 → 1.0.0   (breaking changes)
+npm run release:minor      # 0.1.2 → 0.2.0   (new features — pre-1.0 may also include minor breaking changes)
+npm run release:major      # 0.1.2 → 1.0.0   (breaking changes post-1.0)
 ```
+
+Before 1.0 the project follows the looser pre-1.0 semver convention:
+breaking changes are allowed in minor bumps, but still call them out
+prominently in the release notes (`gh release create --notes`).
+Command/flag removals go under a "Breaking" heading.
 
 Each of these:
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*"
   },
   "engines": {
     "node": ">=18"

--- a/pi-extension/companion.mjs
+++ b/pi-extension/companion.mjs
@@ -12,7 +12,14 @@
 //     "project": "...", "status": "thinking", "detail": "...",
 //     "prompt": "...", "ctxPct": 34, "frozenElapsed": <ms>|null }
 //   { "id": "<session-uuid>", "type": "remove" }
-//   { "id": "<session-uuid>", "type": "mode", "mode": "normal"|"notch" }
+//   { "id": "<session-uuid>", "type": "mode",    "mode":  "normal"|"notch" }
+//   { "id": "<session-uuid>", "type": "scale",   "scale": "small"|"medium"|"large" }
+//   { "id": "<session-uuid>", "type": "respawn" }
+//
+// On startup the companion also reads ~/.pi/pi-island.json for settings it
+// owns (screen, notchMode). Clients bump those via the `respawn` message
+// after updating the pref file — NSWindow geometry is fixed at spawn so a
+// live screen change requires a fresh process.
 //
 // When the last client disconnects we keep the window for 6s so a quick
 // reconnect (pi /new, /reload, etc.) doesn't flash the capsule closed,
@@ -20,29 +27,44 @@
 
 import { createServer } from "node:net";
 import { createInterface } from "node:readline";
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { openFixed } from "./open-fixed.mjs";
 import { buildIslandHTML } from "./island.html.mjs";
 import { SOCK } from "./socket-path.mjs";
 
-// ---- Screen geometry ------------------------------------------------------
-// Find the screen to host the island on. Strategy:
-//   1. Screen under the mouse cursor (what the user is looking at right now).
-//   2. NSScreen.mainScreen  (menu-bar / focused screen).
-//   3. NSScreen.screens[0]  (last-resort, documented as arbitrary order).
-//
-// We return the screen's *global* origin in addition to its size, so the
-// caller can place the window in the global coordinate space instead of
-// accidentally using screen-local coords as global ones (which lands the
-// window in a random spot on multi-monitor setups).
-function getScreenGeometry() {
+// ---- User preference --------------------------------------------------
+// Small subset of ~/.pi/pi-island.json that this process cares about.
+// The client-side extension owns the full schema; we only read the two
+// fields that drive geometry (screen + notchMode) and silently ignore
+// the rest so old/new formats coexist.
+const PREF_FILE = join(homedir(), ".pi", "pi-island.json");
+
+function readPref() {
   try {
-    const script =
-      "ObjC.import('AppKit');" +
+    if (!existsSync(PREF_FILE)) return {};
+    const data = JSON.parse(readFileSync(PREF_FILE, "utf8"));
+    return data && typeof data === "object" ? data : {};
+  } catch { return {}; }
+}
+
+// ---- Screen geometry ------------------------------------------------------
+// Pick the target NSScreen based on the user preference:
+//
+//   "primary"  → NSScreen.screens[0]  (menu-bar screen, AGENT.md §6.1 original)
+//   "active"   → screen under the mouse cursor at spawn (multi-monitor follow)
+//   "N" (1..)  → specific display index (1 == screens[0] == primary)
+//
+// Any unknown / missing value falls back to primary. We still return the
+// screen's *global* origin so the caller can place the window in global
+// coordinate space (Cocoa uses bottom-left) on multi-monitor setups.
+function buildScreenSelectorJXA(screenPref) {
+  if (screenPref === "active") {
+    return (
       "const mouse = $.NSEvent.mouseLocation;" +
       "const all = $.NSScreen.screens.js;" +
-      "let s = null;" +
       "for (const scr of all) {" +
       "  const f = scr.frame;" +
       "  if (mouse.x >= f.origin.x && mouse.x < f.origin.x + f.size.width &&" +
@@ -50,8 +72,29 @@ function getScreenGeometry() {
       "    s = scr; break;" +
       "  }" +
       "}" +
-      "if (!s) s = $.NSScreen.mainScreen;" +
-      "if (!s || !s.frame) s = all[0];" +
+      "if (!s) s = $.NSScreen.mainScreen;"
+    );
+  }
+  const idx = parseInt(screenPref, 10);
+  if (Number.isFinite(idx) && idx >= 1) {
+    // Clamp to available screens inside the JXA runtime so out-of-range
+    // indices don't explode — fall back to screens[0].
+    return (
+      "const all = $.NSScreen.screens.js;" +
+      `s = all[${idx - 1}] || all[0];`
+    );
+  }
+  // "primary" or anything unknown.
+  return "s = $.NSScreen.screens.js[0];";
+}
+
+function getScreenGeometry(screenPref) {
+  try {
+    const script =
+      "ObjC.import('AppKit');" +
+      "let s = null;" +
+      buildScreenSelectorJXA(screenPref) +
+      "if (!s || !s.frame) s = $.NSScreen.screens.js[0];" +
       "const f = s.frame;" +
       "const sa = (s.safeAreaInsets && s.safeAreaInsets.top) || 0;" +
       "JSON.stringify({x: f.origin.x, y: f.origin.y, w: f.size.width, h: f.size.height, notch: sa})";
@@ -80,20 +123,39 @@ function getScreenGeometry() {
 const WIN_W = 640;
 const WIN_H = 420; // room for ~10 rows comfortably
 
+// Pull settings from the pref file (client may have written them before
+// spawning us). Missing / bogus values fall back to safe defaults.
+const _pref = readPref();
+const SCREEN_PREF =
+  typeof _pref.screen === "string" && _pref.screen.length > 0
+    ? _pref.screen
+    : "primary";
+const NOTCH_PREF =
+  _pref.notchMode === "normal" || _pref.notchMode === "notch"
+    ? _pref.notchMode
+    : "auto";
+
 const {
   x: screenX,
   y: screenY,
   width:  screenW,
   height: screenH,
   notch:  notchH,
-} = getScreenGeometry();
+} = getScreenGeometry(SCREEN_PREF);
 
-// Place the window top-center of the *active* screen, in the global
+// Place the window top-center of the chosen screen, in the global
 // coordinate space (macOS uses bottom-left origin; larger y = further up).
 const x = Math.round(screenX + (screenW - WIN_W) / 2);
 const y = Math.round(screenY + screenH - WIN_H);
 
-const autoMode = notchH > 0 ? "notch" : "normal";
+// Resolve the notch policy:
+//   "normal"  → force off regardless of detection
+//   "notch"   → force on regardless of detection
+//   anything else ("auto") → use the detected value
+const autoMode =
+  NOTCH_PREF === "normal" ? "normal" :
+  NOTCH_PREF === "notch"  ? "notch"  :
+  (notchH > 0 ? "notch" : "normal");
 
 const win = openFixed(buildIslandHTML(), {
   width: WIN_W, height: WIN_H, x, y,
@@ -153,6 +215,21 @@ const server = createServer((sock) => {
     }
     if (msg.type === "mode" && (msg.mode === "normal" || msg.mode === "notch")) {
       send(`window.island.setMode(${JSON.stringify(msg.mode)})`);
+      return;
+    }
+    if (msg.type === "scale" && typeof msg.scale === "string") {
+      // WebView clamps unknown scales to medium — we don't need to validate
+      // here, just forward. This keeps the companion agnostic to the preset
+      // list so new sizes can land in index.ts + island.html.mjs without a
+      // companion change.
+      send(`window.island.setScale(${JSON.stringify(msg.scale)})`);
+      return;
+    }
+    if (msg.type === "respawn") {
+      // Graceful shutdown so the client's next ensureConnection() spawns
+      // a fresh companion that re-reads the pref file (new screen / notch).
+      cleanup();
+      process.exit(0);
       return;
     }
     // Default: treat as an upsert.

--- a/pi-extension/demo.mjs
+++ b/pi-extension/demo.mjs
@@ -3,8 +3,15 @@
 // Spawns the companion, then plays back a script with two simulated pi
 // sessions so you can see rows appear, update, and stack vertically.
 //
-//   node pi-extension/demo.mjs          # stack demo (default)
-//   node pi-extension/demo.mjs single   # single-row walkthrough
+//   node pi-extension/demo.mjs                       # stack demo (default)
+//   node pi-extension/demo.mjs single                # single-row walkthrough
+//   node pi-extension/demo.mjs overlap               # long project name + long prompt
+//   node pi-extension/demo.mjs long                  # 1000s elapsed, ticks forever (Ctrl+C to quit)
+//   node pi-extension/demo.mjs sizes                 # one row per preset stacked (xlarge→small)
+//   node pi-extension/demo.mjs single large          # scale preset (small|medium|large)
+//   node pi-extension/demo.mjs stack small
+//   node pi-extension/demo.mjs overlap large
+//   node pi-extension/demo.mjs long large            # also works for long
 
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
@@ -15,7 +22,8 @@ import { SOCK } from "./socket-path.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const COMPANION = join(HERE, "companion.mjs");
-const MODE = process.argv[2] || "stack";
+const MODE  = process.argv[2] || "stack";
+const SCALE = process.argv[3] || null; // optional: "small" | "medium" | "large"
 
 // ---- Ensure companion is running and get a connected socket ---------------
 function tryConnect() {
@@ -105,13 +113,94 @@ const SCRIPT_SINGLE = [
   { delay: 2500, status: "done",      prompt: "fix the auth bug in login.ts", ctx: 88, freeze: true },
 ];
 
+// Regression demo for the project-name/prompt overlap (GitHub issue #4).
+// Long project basename on the left + long prompt in the middle exercises
+// both the TS source-side truncation and the CSS ellipsis safety net.
+const SCRIPT_OVERLAP = [
+  { delay:    0, status: "thinking",  prompt: "this is a deliberately long prompt to stress the middle slot", ctx: 5 },
+  { delay: 2000, status: "editing",   detail: "index.ts", ctx: 12 },
+  { delay: 2000, status: "running",   detail: "npm",      ctx: 18 },
+  { delay: 2500, status: "done",      prompt: "this is a deliberately long prompt to stress the middle slot", ctx: 20, freeze: true },
+];
+
 // ---- Main -----------------------------------------------------------------
 const sock = await getClient();
 
-if (MODE === "single") {
+// Apply size preset up-front if requested. Unknown values fall back to
+// medium on the WebView side, so typos don't break the demo.
+if (SCALE) {
+  sendMsg(sock, { id: "sess-demo", type: "scale", scale: SCALE });
+  await sleep(50);
+}
+
+if (MODE === "sizes") {
+  // Showcase demo: one row per size preset, stacked largest-on-top. Each
+  // row gets its own `rowScale` so CSS --scale is set inline on that row
+  // specifically (the island.html renderer applies it). Great for a
+  // promo video — Ctrl+C to exit.
+  const scales = ["xlarge", "large", "medium", "small"];
+  const now = Date.now();
+  for (let i = 0; i < scales.length; i++) {
+    const s = scales[i];
+    sendMsg(sock, {
+      id: `sess-${s}`,
+      type: "update",
+      project: "pi-island",
+      status: "thinking",
+      prompt: `size: ${s}`,
+      startedAt: now - (i + 1) * 1000 * 3,
+      ctxPct: 20 + i * 15,
+      rowScale: s,
+    });
+    await sleep(600); // stagger enter animations so rows fade in one by one
+  }
+  console.log("\n4 sizes stacked (xlarge → small). Ctrl+C to exit.\n");
+  process.on("SIGINT", () => {
+    for (const s of scales) sendMsg(sock, { id: `sess-${s}`, type: "remove" });
+    setTimeout(() => { sock.end(); process.exit(0); }, 300);
+  });
+  await new Promise(() => {});
+} else if (MODE === "long") {
+  // Long-running task demo. Sends one upsert with startedAt set 1000s in
+  // the past so the elapsed readout starts at 16m 40s and keeps climbing
+  // live (the WebView's 250ms ticker does the ongoing increments). The
+  // client keeps the socket open forever — Ctrl+C to exit. While the
+  // socket is alive the companion never idle-exits, so this is the
+  // right mode for "leave the island up and stare at it".
+  const id = "sess-long";
+  const startedAt = Date.now() - 1000 * 1000;
+  sendMsg(sock, {
+    id, type: "update",
+    project: "pi-island",
+    status: "thinking",
+    prompt: "long running task",
+    startedAt,
+    ctxPct: 42,
+  });
+  console.log("\nisland is pinned — elapsed shows 16m 40s and climbs. Ctrl+C to quit.\n");
+  // Clean up on SIGINT so the companion idle-exits promptly.
+  process.on("SIGINT", () => {
+    sendMsg(sock, { id, type: "remove" });
+    setTimeout(() => { sock.end(); process.exit(0); }, 200);
+  });
+  // Block forever.
+  await new Promise(() => {});
+} else if (MODE === "single") {
   await playSession(sock, "sess-single", "pi-test", SCRIPT_SINGLE);
   await sleep(3000);
   sendMsg(sock, { id: "sess-single", type: "remove" });
+} else if (MODE === "overlap") {
+  // Long basename the extension would have (pre-truncation) next to a
+  // long prompt. The extension truncates to 20 chars; here we send raw
+  // so we can see what CSS does on its own too.
+  await playSession(
+    sock,
+    "sess-overlap",
+    "pi-pi-pi-pi-pi-pi-pi-pi-pi-pi-pi-pi-pi",
+    SCRIPT_OVERLAP,
+  );
+  await sleep(3000);
+  sendMsg(sock, { id: "sess-overlap", type: "remove" });
 } else {
   // Three concurrent sessions, staggered so you can watch them stack.
   const a = playSession(sock, "sess-a", "pi-auth",      SCRIPT_A);

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -13,8 +13,10 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
+import { Container, SettingsList, type SettingItem } from "@mariozechner/pi-tui";
 import { connect, type Socket } from "node:net";
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 import { basename, join, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
@@ -27,28 +29,107 @@ const COMPANION = join(HERE, "companion.mjs");
 const SESSION_ID = randomUUID().slice(0, 8);
 
 // ── Persistent user preference ─────────────────────────────────────────────
-// The capsule is ON by default — users installed this extension because they
-// want to see it. Typing `/island` toggles OFF and persists the choice in
-// ~/.pi/pi-island.json so every future pi session respects it without the
-// user having to retype the command. Typing `/island` again flips it back ON.
+// Every user-visible setting that survives restarts lives in ~/.pi/pi-island.json.
+// Fields are all optional in the on-disk file — missing ones fall back to
+// sensible defaults so old installs keep working on upgrade.
+//
+//   {
+//     "enabled":   true,            // visibility toggle
+//     "scale":     "medium",        // size preset
+//     "screen":    "primary",       // which display
+//     "notchMode": "auto"           // notch-wrap policy
+//   }
+//
+// The companion reads the same file at spawn time for settings it owns
+// (screen + notch). Settings that change live (size, visibility) are
+// delivered over the socket as well.
 const PREF_DIR  = join(homedir(), ".pi");
 const PREF_FILE = join(PREF_DIR, "pi-island.json");
 
-function readPreference(): boolean {
+// Scale presets — mirrors SCALES in island.html.mjs. Adding a preset
+// requires updates in BOTH files (the list here drives the settings
+// menu / validation; the map over there drives the actual CSS scale).
+const SCALES = ["small", "medium", "large", "xlarge"] as const;
+type Scale = typeof SCALES[number];
+const DEFAULT_SCALE: Scale = "medium";
+
+// Screen preference:
+//   "primary" → NSScreen.screens[0] (menu-bar screen, AGENT.md §6.1 original)
+//   "active"  → screen under the mouse cursor at companion spawn (PR #3)
+//   "2"..."N" → specific monitor by index (1 == primary, so the menu hides it)
+type ScreenPref = string;
+const DEFAULT_SCREEN: ScreenPref = "primary";
+
+// Notch wrap policy:
+//   "auto"   → companion auto-detects via safeAreaInsets (default, pre-0.2 behaviour)
+//   "normal" → force disable (useful if auto-detection misfires)
+//   "notch"  → force enable (replaces the removed /island2 command)
+const NOTCH_MODES = ["auto", "normal", "notch"] as const;
+type NotchMode = typeof NOTCH_MODES[number];
+const DEFAULT_NOTCH: NotchMode = "auto";
+
+type Preference = {
+  enabled:   boolean;
+  scale:     Scale;
+  screen:    ScreenPref;
+  notchMode: NotchMode;
+};
+
+function isScale(v: unknown): v is Scale {
+  return typeof v === "string" && (SCALES as readonly string[]).includes(v);
+}
+function isNotchMode(v: unknown): v is NotchMode {
+  return typeof v === "string" && (NOTCH_MODES as readonly string[]).includes(v);
+}
+// "primary" | "active" | "1" | "2" | ... — numeric must be a clean integer ≥ 1.
+function isScreen(v: unknown): v is ScreenPref {
+  if (typeof v !== "string") return false;
+  if (v === "primary" || v === "active") return true;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n >= 1 && String(n) === v;
+}
+
+function readPreference(): Preference {
+  const fallback: Preference = {
+    enabled:   true,
+    scale:     DEFAULT_SCALE,
+    screen:    DEFAULT_SCREEN,
+    notchMode: DEFAULT_NOTCH,
+  };
   try {
-    if (!existsSync(PREF_FILE)) return true; // default ON
+    if (!existsSync(PREF_FILE)) return fallback;
     const data = JSON.parse(readFileSync(PREF_FILE, "utf8"));
-    return data?.enabled !== false;
+    return {
+      enabled:   data?.enabled   !== false,
+      scale:     isScale(data?.scale)          ? data.scale     : DEFAULT_SCALE,
+      screen:    isScreen(data?.screen)        ? data.screen    : DEFAULT_SCREEN,
+      notchMode: isNotchMode(data?.notchMode)  ? data.notchMode : DEFAULT_NOTCH,
+    };
   } catch {
-    return true;
+    return fallback;
   }
 }
 
-function writePreference(enabled: boolean): void {
+function writePreference(p: Preference): void {
   try {
     if (!existsSync(PREF_DIR)) mkdirSync(PREF_DIR, { recursive: true });
-    writeFileSync(PREF_FILE, JSON.stringify({ enabled }, null, 2) + "\n");
+    writeFileSync(PREF_FILE, JSON.stringify(p, null, 2) + "\n");
   } catch { /* best-effort — don't crash the session over a cache file */ }
+}
+
+// Query macOS for the number of attached displays. Used to build the
+// Screen dropdown in the settings menu; capped at something sane so a
+// weird system with 20 fake displays doesn't produce a 20-entry menu.
+function getScreenCount(): number {
+  try {
+    const out = execSync(
+      `osascript -l JavaScript -e "ObjC.import('AppKit'); $.NSScreen.screens.js.length"`,
+      { encoding: "utf8", timeout: 1500 },
+    ).trim();
+    const n = parseInt(out, 10);
+    if (!Number.isFinite(n) || n < 1) return 1;
+    return Math.min(n, 9);
+  } catch { return 1; }
 }
 
 // ── tool name → island state (matches pi's built-in tool set) ──────────────
@@ -80,6 +161,16 @@ function truncatePrompt(s: string, max = 48): string {
   return clean.length > max ? clean.slice(0, max - 1) + "…" : clean;
 }
 
+// Project names come from `basename(process.cwd())` — usually short
+// (`pi-island`, `my-app`) but occasionally pathological. Clamp at the
+// source so the socket never ships 200-char strings; CSS adds a second
+// ellipsis safety net in case this ever regresses.
+function truncateProject(s: string, max = 20): string {
+  const clean = String(s || "");
+  if (!clean) return "";
+  return clean.length > max ? clean.slice(0, max - 1) + "…" : clean;
+}
+
 // ── extension entry ────────────────────────────────────────────────────────
 export default function (pi: ExtensionAPI) {
   if (process.platform !== "darwin") return; // mac-only by design
@@ -87,19 +178,29 @@ export default function (pi: ExtensionAPI) {
   // ── Client state ─────────────────────────────────────────────────────────
   let sock: Socket | null = null;
   let connecting = false;
-  // Default-on: read persisted preference. First-time users see the island
-  // immediately; users who've previously typed /island to disable stay
-  // disabled across restarts.
-  let shownForSession = readPreference();
+  const pref = readPreference();
+  let shownForSession    = pref.enabled;
+  let currentScale:     Scale      = pref.scale;
+  let currentScreen:    ScreenPref = pref.screen;
+  let currentNotchMode: NotchMode  = pref.notchMode;
   let hideTimer: NodeJS.Timeout | null = null;
 
-  const project = basename(process.cwd());
+  const project = truncateProject(basename(process.cwd()));
   let lastCtx: any = null;
   let activeToolCount = 0;
   let inAgent = false;
   let currentPrompt = "";
   let startedAt: number | null = null;
   let frozenElapsed: number | null = null;
+
+  function persistPref() {
+    writePreference({
+      enabled:   shownForSession,
+      scale:     currentScale,
+      screen:    currentScreen,
+      notchMode: currentNotchMode,
+    });
+  }
 
   // ── Socket connection ────────────────────────────────────────────────────
   function connectToCompanion(): Promise<boolean> {
@@ -117,13 +218,20 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
+  // Tell the companion the client's current visual scale. Pushed on every
+  // fresh connect so a freshly-spawned companion (medium by default) picks
+  // up the user's pref without waiting for an explicit size change.
+  function syncScale() {
+    writeMessage({ id: SESSION_ID, type: "scale", scale: currentScale });
+  }
+
   async function ensureConnection(): Promise<boolean> {
     if (sock && !sock.destroyed) return true;
     if (connecting) return false;
     connecting = true;
     try {
       // Try connecting to an existing companion first.
-      if (existsSync(SOCK) && await connectToCompanion()) return true;
+      if (existsSync(SOCK) && await connectToCompanion()) { syncScale(); return true; }
 
       // Otherwise spawn the companion and poll until the socket is up.
       if (!existsSync(COMPANION)) return false;
@@ -135,7 +243,7 @@ export default function (pi: ExtensionAPI) {
 
       for (let i = 0; i < 30; i++) {
         await new Promise((r) => setTimeout(r, 100));
-        if (await connectToCompanion()) return true;
+        if (await connectToCompanion()) { syncScale(); return true; }
       }
       return false;
     } finally {
@@ -178,11 +286,173 @@ export default function (pi: ExtensionAPI) {
     writeMessage({ id: SESSION_ID, type: "remove" });
   }
 
+  // Ask the companion to cleanly exit so the client's next event respawns
+  // it with fresh pref values. Used for settings that need a new NSWindow
+  // (screen position, notch mode) — NSWindow geometry is fixed after spawn.
+  async function respawnCompanion() {
+    if (sock && !sock.destroyed) {
+      writeMessage({ id: SESSION_ID, type: "respawn" });
+      try { sock.end(); } catch {}
+      sock = null;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    if (shownForSession) await ensureConnection();
+  }
+
+  // ── Setting actions (shared between /island subcommands and the menu) ────
+  async function doEnable(ctx: any) {
+    shownForSession = true;
+    persistPref();
+    await ensureConnection();
+    ctx.ui.notify("Island enabled", "info");
+  }
+
+  async function doDisable(ctx: any) {
+    shownForSession = false;
+    persistPref();
+    if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+    await sendRemove();
+    ctx.ui.notify("Island disabled", "info");
+  }
+
+  async function doSetScale(next: Scale, ctx: any) {
+    currentScale = next;
+    persistPref();
+    // Scale is live — no companion respawn needed. CSS var flips instantly.
+    if (sock && !sock.destroyed) {
+      syncScale();
+    } else if (shownForSession) {
+      if (await ensureConnection()) syncScale();
+    }
+    ctx.ui.notify(`Island size → ${next}`, "info");
+  }
+
+  async function doSetScreen(next: ScreenPref, ctx: any) {
+    currentScreen = next;
+    persistPref();
+    await respawnCompanion();
+    ctx.ui.notify(`Island screen → ${next}`, "info");
+  }
+
+  async function doSetNotchMode(next: NotchMode, ctx: any) {
+    currentNotchMode = next;
+    persistPref();
+    await respawnCompanion();
+    ctx.ui.notify(`Island notch wrap → ${next}`, "info");
+  }
+
+  // ── Settings menu — same UX as pi's /settings ────────────────────────────
+  // Uses pi-tui's SettingsList component via ctx.ui.custom(). Each row
+  // shows a label + current value; Enter/Space cycles through `values`.
+  // The action callbacks are the same helpers the /island subcommands use,
+  // so menu and CLI stay perfectly in sync.
+  //
+  // IMPORTANT pattern notes (learned the hard way):
+  //   - Do NOT pass { overlay: true }. It puts us in a narrow floating box
+  //     that bleeds terminal scrollback through the transparent areas
+  //     (rendering garbage). Full-width in-flow render — same layout as
+  //     pi's own /settings — needs no options at all.
+  //   - The factory MUST return an object with explicit render/invalidate/
+  //     handleInput — NOT the Container directly. Container doesn't route
+  //     keystrokes to its active focusable child, so the list would never
+  //     see Enter/Space/arrows and the terminal looks frozen.
+  //   - handleInput must call tui.requestRender() after each keystroke or
+  //     the cycled value doesn't repaint until the next unrelated event.
+  async function openSettingsMenu(ctx: any) {
+    if (!ctx.hasUI) {
+      ctx.ui.notify(
+        "Settings menu needs an interactive UI. Try /island size|screen|notch <value>",
+        "info",
+      );
+      return;
+    }
+
+    const screenCount = getScreenCount();
+    const screenValues: string[] = ["primary", "active"];
+    for (let i = 2; i <= screenCount; i++) screenValues.push(String(i));
+
+    await ctx.ui.custom<void>((tui: any, theme: any, _kb: any, done: (r?: void) => void) => {
+      const items: SettingItem[] = [
+          {
+            id: "visibility",
+            label: "Visibility",
+            description: "Show or hide the Dynamic Island capsule at the top of the screen",
+            currentValue: shownForSession ? "enabled" : "disabled",
+            values: ["enabled", "disabled"],
+          },
+          {
+            id: "size",
+            label: "Size",
+            description: "Font size / row height preset (live — no restart needed)",
+            currentValue: currentScale,
+            values: [...SCALES],
+          },
+          {
+            id: "screen",
+            label: "Screen",
+            description: "Display to host the capsule (primary = menu-bar screen; active = follow mouse; 2/3/… = monitor index)",
+            currentValue: currentScreen,
+            values: screenValues,
+          },
+          {
+            id: "notch",
+            label: "Notch wrap",
+            description: "Wrap the MacBook notch (auto = detect; normal = force off; notch = force on)",
+            currentValue: currentNotchMode,
+            values: [...NOTCH_MODES],
+          },
+        ];
+
+      const container = new Container();
+      const border = () => new DynamicBorder((s: string) => theme.fg("accent", s));
+      container.addChild(border());
+
+      const list = new SettingsList(
+        items,
+        10,
+        getSettingsListTheme(),
+        (id: string, newValue: string) => {
+          // Fire-and-forget — SettingsList doesn't await us. Any failure
+          // just leaves the displayed value updated but the real setting
+          // unchanged. In practice all our do*() helpers are robust.
+          (async () => {
+            if (id === "visibility") {
+              if (newValue === "enabled") await doEnable(ctx);
+              else await doDisable(ctx);
+            } else if (id === "size" && isScale(newValue)) {
+              await doSetScale(newValue, ctx);
+            } else if (id === "screen" && isScreen(newValue)) {
+              await doSetScreen(newValue, ctx);
+            } else if (id === "notch" && isNotchMode(newValue)) {
+              await doSetNotchMode(newValue, ctx);
+            }
+          })();
+          list.updateValue(id, newValue);
+        },
+        () => done(undefined),
+        { enableSearch: false },
+      );
+      container.addChild(list);
+      container.addChild(border());
+
+      // Explicit Component-shaped return so keystrokes actually reach the
+      // SettingsList (Container alone swallows them). See header comment.
+      return {
+        render(width: number) { return container.render(width); },
+        invalidate()            { container.invalidate(); },
+        handleInput(data: string) {
+          list.handleInput(data);
+          tui.requestRender();
+        },
+      };
+    });
+  }
+
   // ── Event handlers ───────────────────────────────────────────────────────
   pi.on("session_start", async (_evt, ctx) => {
     lastCtx = ctx;
-    // Don't auto-show on session start — user opts in via /island. This
-    // mirrors the existing single-mode behaviour.
+    // Don't auto-show on session start — the island appears on the first
+    // agent_start event (when there's actually something to show).
   });
 
   pi.on("session_shutdown", async () => {
@@ -244,37 +514,93 @@ export default function (pi: ExtensionAPI) {
     hideTimer = setTimeout(async () => { await sendRemove(); }, 5000);
   });
 
-  // ── /island command — toggle visibility (persisted across sessions) ──────
+  // ── /island command ──────────────────────────────────────────────────────
+  //
+  //   /island                   → open settings menu (canonical)
+  //   /island on | enable       → show + persist
+  //   /island off | disable     → hide + persist
+  //   /island toggle            → flip current visibility
+  //   /island size <preset>     → set scale (small | medium | large)
+  //   /island screen <value>    → set screen (primary | active | 2 | 3 ...)
+  //   /island notch <mode>      → set notch wrap (auto | normal | notch)
+  //
+  // Subcommands let power users / scripts skip the menu. With no args the
+  // menu is the friendlier path — same UX as pi's own /settings.
   pi.registerCommand("island", {
-    description: "Toggle the pi Dynamic Island (remembers your choice)",
-    handler: async (_args, ctx) => {
-      if (shownForSession) {
-        shownForSession = false;
-        writePreference(false);
-        if (hideTimer) clearTimeout(hideTimer);
-        await sendRemove();
-        ctx.ui.notify("Island disabled — won't appear until you /island again", "info");
-      } else {
-        shownForSession = true;
-        writePreference(true);
-        await ensureConnection();
-        ctx.ui.notify("Island enabled — will auto-show on every pi session", "info");
-      }
-    },
-  });
-
-  // ── /island2 command — force notch-mode layout on the companion ──────────
-  pi.registerCommand("island2", {
-    description: "Force the companion into notch-wrap layout",
-    handler: async (_args, ctx) => {
-      shownForSession = true;
-      writePreference(true);
-      if (!(await ensureConnection())) {
-        ctx.ui.notify("Couldn't reach the island companion", "error");
+    description: "Open pi-island settings (or /island size|screen|notch <value>)",
+    handler: async (args, ctx) => {
+      const parts = String(args ?? "").trim().split(/\s+/).filter(Boolean);
+      if (parts.length === 0) {
+        await openSettingsMenu(ctx);
         return;
       }
-      writeMessage({ id: SESSION_ID, type: "mode", mode: "notch" });
-      ctx.ui.notify("Island switched to notch-wrap mode", "info");
+      const sub = parts[0]?.toLowerCase();
+
+      if (sub === "on" || sub === "enable") { await doEnable(ctx);  return; }
+      if (sub === "off" || sub === "disable") { await doDisable(ctx); return; }
+      if (sub === "toggle") {
+        if (shownForSession) await doDisable(ctx); else await doEnable(ctx);
+        return;
+      }
+
+      if (sub === "size") {
+        const next = parts[1]?.toLowerCase();
+        if (!next) {
+          ctx.ui.notify(`Size: ${currentScale} — try /island size <${SCALES.join("|")}>`, "info");
+          return;
+        }
+        if (!isScale(next)) {
+          ctx.ui.notify(`Unknown size "${next}". Use one of: ${SCALES.join(", ")}`, "error");
+          return;
+        }
+        await doSetScale(next, ctx);
+        return;
+      }
+
+      if (sub === "screen") {
+        const next = parts[1]?.toLowerCase();
+        if (!next) {
+          ctx.ui.notify(
+            `Screen: ${currentScreen} — try /island screen <primary|active|2|3|...>`,
+            "info",
+          );
+          return;
+        }
+        if (!isScreen(next)) {
+          ctx.ui.notify(
+            `Unknown screen "${next}". Use: primary, active, or a monitor index (1..N)`,
+            "error",
+          );
+          return;
+        }
+        await doSetScreen(next, ctx);
+        return;
+      }
+
+      if (sub === "notch") {
+        const next = parts[1]?.toLowerCase();
+        if (!next) {
+          ctx.ui.notify(
+            `Notch wrap: ${currentNotchMode} — try /island notch <${NOTCH_MODES.join("|")}>`,
+            "info",
+          );
+          return;
+        }
+        if (!isNotchMode(next)) {
+          ctx.ui.notify(
+            `Unknown notch mode "${next}". Use one of: ${NOTCH_MODES.join(", ")}`,
+            "error",
+          );
+          return;
+        }
+        await doSetNotchMode(next, ctx);
+        return;
+      }
+
+      ctx.ui.notify(
+        `Unknown subcommand "${sub}". Try: /island (menu)  or  /island size|screen|notch <value>`,
+        "error",
+      );
     },
   });
 }

--- a/pi-extension/island.html.mjs
+++ b/pi-extension/island.html.mjs
@@ -20,6 +20,15 @@ export function buildIslandHTML() {
 <head>
 <meta charset="utf-8">
 <style>
+/* ---------- Global scale ----------
+ * One CSS custom property drives font-size, row-height, padding, gap and
+ * meta sizing. window.island.setScale(name) flips it at runtime.
+ * Row width and slot geometry (130/150/auto) stay FIXED so the absolute-
+ * centered middle slot keeps its pixel-stable position regardless of
+ * user-picked scale. Text inside scaled slots ellipsises naturally when
+ * it runs out of room. */
+:root { --scale: 1; }
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body {
   width: 100%;
@@ -56,9 +65,13 @@ html, body {
   color: #fff;
   /* Default: square corners. First / last get rounded below. */
   border-radius: 0;
-  width: 460px;
-  height: 34px;
-  padding: 0 14px;
+  /* Width scales together with font-size so the left/middle/right slot
+   * proportions stay balanced — otherwise the middle-slot prompt text
+   * looks visually squeezed at larger scales. At scale 1.18 (large) the
+   * row is 543px wide, which still fits inside the 640px host window. */
+  width: calc(460px * var(--scale));
+  height: calc(34px * var(--scale));
+  padding: 0 calc(14px * var(--scale));
   /* The row uses a simple flex for left/right slots. The MIDDLE slot is
    * absolutely positioned at the row's geometric center (see .slot.mid)
    * so its text never shifts by a single pixel when the right-side label
@@ -69,8 +82,8 @@ html, body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 10px;
-  font-size: 11.5px;
+  gap: calc(10px * var(--scale));
+  font-size: calc(11.5px * var(--scale));
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
@@ -85,7 +98,7 @@ html, body {
 }
 .row.visible {
   opacity: 1;
-  max-height: 34px;
+  max-height: calc(34px * var(--scale));
 }
 
 /* Hairline between consecutive rows so they look stacked, not monolithic. */
@@ -95,21 +108,42 @@ html, body {
  * continuous "capsule" look regardless of how many rows are stacked.
  * No drop-shadow: the capsule is pure black against whatever sits below
  * it, just like the real iPhone Dynamic Island. */
-.row.visible:last-of-type { border-radius: 0 0 22px 22px; }
+.row.visible:last-of-type {
+  border-radius: 0 0 calc(22px * var(--scale)) calc(22px * var(--scale));
+}
 
 /* Notch mode: the FIRST row's middle is always empty (the notch lives
  * there). Subsequent rows (below the notch) behave like normal pills. */
 body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
 
+/* Notch mode, first row only: abbreviate the elapsed timer by hiding
+ * its "sub" part (the seconds after "Xm" or the minutes after "Xh").
+ * The right slot grows leftward as the timer widens and on a notched
+ * MacBook the right slot's left edge would otherwise slide behind the
+ * notch (~225–430px in from the left). With abbreviation the timer
+ * plateaus at 3–4 chars ("16m", "1h", "12h") instead of climbing to 7+
+ * chars ("16m 52s", "12h 34m"), which is enough headroom for the
+ * status label + ctx% to clear the notch cleanly. Rows BELOW the notch
+ * (second + onwards) keep the full readout — they sit under the menu
+ * bar and have no clipping issue. */
+body.notch-mode .row:first-child .t-sub { display: none; }
+
 .slot {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: calc(7px * var(--scale));
   min-width: 0;
 }
-/* Left & right live in the flex row, shrinking naturally but keeping
- * their positions pinned to the row edges. */
-.slot.left  { flex: 0 0 auto; }
+/* Left & right live in the flex row. Left gets a hard max-width so a
+ * long project name (e.g. a deeply-nested repo folder) can't visually
+ * crash into the absolutely-centered middle slot. The project <span>
+ * inside gets text-overflow: ellipsis so the truncation is graceful. */
+.slot.left  {
+  flex: 0 1 auto;
+  max-width: calc(130px * var(--scale));
+  min-width: 0;
+  overflow: hidden;
+}
 .slot.right { flex: 0 0 auto; }
 /* Middle is absolutely centered on the row. Because it's out of flow,
  * its position is defined ONLY by the row's width — independent of the
@@ -123,17 +157,19 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
   transform: translateX(-50%);
   justify-content: center;
   overflow: hidden;
-  /* Keep clear of left/right slots: row is 460px, padding 14*2=28,
-   * left ≈ 130, right ≈ 170, plus a little breathing room. */
-  max-width: 150px;
+  /* Keep clear of left/right slots: at scale 1.0 row is 460px, padding
+   * 14*2=28, left ≤ 130, right ≈ 170, plus a little breathing room. All
+   * proportions scale together via var(--scale) so the middle slot grows
+   * the prompt area at large sizes instead of clipping aggressively. */
+  max-width: calc(150px * var(--scale));
   pointer-events: none;
 }
 
 .braille {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 13px;
+  font-size: calc(13px * var(--scale));
   line-height: 1;
-  width: 13px;
+  width: calc(13px * var(--scale));
   text-align: center;
   flex-shrink: 0;
   display: inline-block;
@@ -143,14 +179,20 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
   color: rgba(255,255,255,0.96);
   font-weight: 600;
   letter-spacing: -0.1px;
-  flex-shrink: 0;
+  /* Truncate long project names with an ellipsis instead of letting the
+   * left slot overflow into the middle slot. min-width: 0 is required
+   * on flex items for text-overflow: ellipsis to actually kick in. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .sep    { color: rgba(255,255,255,0.28); flex-shrink: 0; }
 .status { color: rgba(255,255,255,0.92); flex-shrink: 0; }
 .detail {
   color: rgba(255,255,255,0.62);
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--scale));
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
@@ -169,13 +211,13 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
 .prompt::after  { content: '\u201D'; opacity: 0.5; margin-left: 1px; }
 
 .meta {
-  padding-left: 8px;
+  padding-left: calc(8px * var(--scale));
   border-left: 1px solid rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.55);
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 10px;
+  font-size: calc(10px * var(--scale));
   display: flex;
-  gap: 6px;
+  gap: calc(6px * var(--scale));
   align-items: center;
   flex-shrink: 0;
 }
@@ -213,20 +255,44 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
   var tickerB = null; // braille ticker
   var tickerT = null; // elapsed-time ticker
 
+  // Size presets — applied by flipping the --scale custom property on
+  // <html>. Everything in the CSS that uses calc(... * var(--scale))
+  // picks it up instantly; no respawn of the companion needed.
+  //
+  // xlarge's 1.35 is the practical ceiling: at that factor the row is
+  // 460*1.35 = 621px wide, leaving ~19px of clickThrough breathing room
+  // inside the 640px host window. Bumping it higher would require
+  // widening WIN_W in companion.mjs too.
+  var SCALES = { small: 0.88, medium: 1.0, large: 1.18, xlarge: 1.35 };
+
   function esc(s) {
     return String(s == null ? '' : s)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
-  function fmtElapsed(ms) {
-    if (ms < 1000) return (ms / 1000).toFixed(1) + 's';
+  // Split the elapsed readout into a "main" unit and a "sub" unit so the
+  // notch CSS above can hide only the sub part without JS awareness of
+  // notch state. main is always visible ("16m", "1h", "42s"); sub is the
+  // next-finer unit with a leading space (" 52s", " 23m") and gets
+  // display:none inside the notched first row.
+  //
+  // Sub-second resolution is deliberately NOT shown — the readout jumps
+  // straight from 0s → 1s → 2s. Tenths-of-a-second jitter feels twitchy
+  // on a status capsule, and the braille spinner already signals "alive".
+  function fmtElapsedParts(ms) {
     var s = Math.floor(ms / 1000);
-    if (s < 60) return s + 's';
+    if (s < 60) return { main: s + 's', sub: '' };
     var m = Math.floor(s / 60); s = s % 60;
-    if (m < 60) return m + 'm ' + (s < 10 ? '0' : '') + s + 's';
+    if (m < 60) return { main: m + 'm', sub: ' ' + (s < 10 ? '0' : '') + s + 's' };
     var h = Math.floor(m / 60); m = m % 60;
-    return h + 'h ' + (m < 10 ? '0' : '') + m + 'm';
+    return { main: h + 'h', sub: ' ' + (m < 10 ? '0' : '') + m + 'm' };
+  }
+
+  function fmtElapsedHTML(ms) {
+    var f = fmtElapsedParts(ms);
+    return '<span class="t-main">' + f.main + '</span>' +
+           '<span class="t-sub">'  + f.sub  + '</span>';
   }
 
   function anySpinning() {
@@ -267,7 +333,10 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
           if (r.data.frozenElapsed != null) continue;
           var el = r.el.querySelector('.t-elapsed');
           if (el && r.data.startedAt) {
-            el.textContent = fmtElapsed(Date.now() - r.data.startedAt);
+            // innerHTML (not textContent) because the timer is now two
+            // nested spans — .t-main + .t-sub — so notch CSS can hide the
+            // sub part independently.
+            el.innerHTML = fmtElapsedHTML(Date.now() - r.data.startedAt);
           }
         }
         if (!anyRunning()) { clearInterval(tickerT); tickerT = null; }
@@ -301,7 +370,7 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
       right += '<div class="meta">';
       if (d.startedAt) {
         var t = d.frozenElapsed != null ? d.frozenElapsed : (Date.now() - d.startedAt);
-        right += '<span class="mono t-elapsed">' + fmtElapsed(t) + '</span>';
+        right += '<span class="mono t-elapsed">' + fmtElapsedHTML(t) + '</span>';
       }
       if (d.ctxPct != null) {
         if (d.startedAt) right += '<span class="sep">\u00b7</span>';
@@ -318,10 +387,24 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
       '<div class="slot right">' + right + '</div>';
   }
 
+  // Optional per-row scale override. Primarily used by the "sizes" demo
+  // to stack one row of each preset for promo screenshots. Sets --scale
+  // inline on the row element so it wins over the :root global scale
+  // via the normal CSS cascade (everything in .row uses calc() on
+  // var(--scale), which picks up whichever --scale is closest on an
+  // ancestor — inline style on the row itself is the closest). Leaving
+  // it undefined keeps the row on the global scale.
+  function applyRowScale(el, data) {
+    if (typeof data.rowScale === 'string' && SCALES[data.rowScale] != null) {
+      el.style.setProperty('--scale', String(SCALES[data.rowScale]));
+    }
+  }
+
   function upsertRow(id, data) {
     var existing = rows[id];
     if (existing && !existing.removing) {
       existing.data = Object.assign({}, existing.data, data);
+      applyRowScale(existing.el, data);
       renderRowContent(existing);
       startTickers();
       return;
@@ -335,6 +418,7 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
     rows[id] = row;
     order.push(id);
     stack.appendChild(el);
+    applyRowScale(el, data);
     renderRowContent(row);
 
     // Trigger enter animation on next frame
@@ -364,10 +448,17 @@ body.notch-mode .row:first-child .slot.mid { visibility: hidden; }
     document.body.className = mode === 'notch' ? 'notch-mode' : '';
   }
 
+  function setScale(scale) {
+    var factor = SCALES[scale];
+    if (factor == null) factor = SCALES.medium;
+    document.documentElement.style.setProperty('--scale', String(factor));
+  }
+
   window.island = {
     upsertRow: upsertRow,
     removeRow: removeRow,
     setMode: setMode,
+    setScale: setScale,
   };
 })();
 </script>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -93,27 +93,50 @@ export default function Home() {
           </div>
         </section>
 
-        {/* ======================= COMMANDS ======================= */}
-        <section id="commands" className="mt-16 scroll-mt-16">
+        {/* ======================= SETTINGS ======================= */}
+        <section id="settings" className="mt-16 scroll-mt-16">
           <div className="flex items-end justify-between gap-4 border-b border-[color:var(--border)] pb-2 mb-5">
-            <h2 className="font-sans font-semibold text-[17px] tracking-tight">Commands</h2>
+            <h2 className="font-sans font-semibold text-[17px] tracking-tight">Settings</h2>
             <span className="text-[10px] text-[color:var(--foreground-dim)] uppercase tracking-wider">
               inside any pi session
             </span>
           </div>
 
+          <p className="text-[14px] text-[color:var(--foreground-dim)] leading-relaxed mb-5">
+            Type <code className="font-mono text-[12.5px] text-[color:var(--foreground)] bg-[color:var(--background-muted)] px-1.5 py-0.5 rounded border border-[color:var(--border)]">/island</code>{" "}
+            to open the settings panel. Cycle any row with Enter or Space.
+            Choices persist in{" "}
+            <code className="font-mono text-[12px] text-[color:var(--foreground-dim)]">~/.pi/pi-island.json</code>.
+          </p>
+
           <div className="grid sm:grid-cols-2 gap-3">
             <CommandCard
-              name="/island"
-              desc="Toggle the capsule on/off. Default floating position, anchored to the top of your screen."
+              name="Visibility"
+              desc="enabled / disabled — show or hide the capsule. Remembers your choice."
             />
             <CommandCard
-              name="/island2"
-              desc="Notch-wrap variant. Splits around the MacBook notch so the capsule hugs it natively."
+              name="Size"
+              desc="small / medium / large / xlarge — row height and font scale together. Live, no restart."
+            />
+            <CommandCard
+              name="Screen"
+              desc="primary / active / 2 / 3 — pick a monitor. primary = menu-bar display, active = follow mouse."
+            />
+            <CommandCard
+              name="Notch wrap"
+              desc="auto / normal / notch — wrap the MacBook notch automatically, or force it on/off."
             />
           </div>
 
           <p className="mt-5 text-[13px] text-[color:var(--foreground-dim)] leading-relaxed">
+            Skip the menu for muscle memory:{" "}
+            <code className="font-mono text-[12.5px] text-[color:var(--foreground)]">/island size large</code>,{" "}
+            <code className="font-mono text-[12.5px] text-[color:var(--foreground)]">/island screen primary</code>,{" "}
+            <code className="font-mono text-[12.5px] text-[color:var(--foreground)]">/island notch notch</code>,{" "}
+            <code className="font-mono text-[12.5px] text-[color:var(--foreground)]">/island off</code>.
+          </p>
+
+          <p className="mt-3 text-[13px] text-[color:var(--foreground-dim)] leading-relaxed">
             Run pi in multiple terminals — each session gets its own row,
             stacked into one continuous capsule.
           </p>
@@ -129,7 +152,7 @@ export default function Home() {
             <Step num={1} bold="A native Swift host" rest="renders a borderless, click-through WKWebView pinned above every Space and full-screen app." />
             <Step num={2} bold="pi's extension API" rest="streams each turn's status over a Unix domain socket to the host." />
             <Step num={3} bold="Every pi session" rest="gets its own row. Rows stack into a single capsule, sized to the longest row." />
-            <Step num={4} bold="Notch detection" rest="on MacBooks with a notch, /island2 splits the capsule to wrap around it cleanly." />
+            <Step num={4} bold="Notch detection" rest="on MacBooks with a notch, the capsule splits to wrap around it automatically — or force it on/off from the settings menu." />
             <Step num={5} bold="Zero chrome." rest="No dock icon, no Stage Manager clutter — it just lives at the top." />
           </ol>
 

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 const sections = [
   { href: "#overview", label: "Overview", active: true },
   { href: "#install", label: "Install" },
-  { href: "#commands", label: "Commands" },
+  { href: "#settings", label: "Settings" },
   { href: "#how-it-works", label: "How it works" },
 ];
 
@@ -12,12 +12,7 @@ const resources = [
   {
     href: "https://www.npmjs.com/package/pi-island",
     label: "npm",
-  },
-  {
-    href: "https://github.com/phun333/pi-island/blob/main/AGENT.md",
-    label: "AGENT.md",
-  },
-  { href: "https://github.com/phun333/pi-island/blob/main/LICENSE", label: "License" },
+  }
 ];
 
 export default function Sidebar() {
@@ -74,7 +69,7 @@ export default function Sidebar() {
           href="https://github.com/phun333/pi-island/releases"
           className="hover:text-[color:var(--foreground)] transition-colors underline underline-offset-2 decoration-dotted"
         >
-          v0.1.0
+          v0.2.0
         </a>
         <span>·</span>
         <a


### PR DESCRIPTION
Closes https://github.com/phun333/pi-island/issues/4

Fixes the overlap on long project names and ships the bigger
v0.2.0 settings pass in one go.

## Fixes
- Project-name overlap on long paths (truncate + CSS ellipsis).
- Elapsed timer now shows integer seconds, no 0.3s/0.6s jitter.

## New
- `/island` opens a settings menu (pi-tui SettingsList):
  - **Size** — small / medium / large / xlarge (live)
  - **Screen** — primary / active / 2 / 3 …
  - **Notch wrap** — auto / normal / notch
  - **Visibility** — enabled / disabled
- Quick-action subcommands: `/island size large`,
  `/island screen primary`, `/island notch notch`, etc.
- Persisted in `~/.pi/pi-island.json`.

## Breaking
- `/island2` removed. Use `/island` → **Notch wrap** (or
  the `/island notch` quick-action).

3 commits, rebase-merge to keep history.