### PR TITLE
feat(island): /island reset and /island reload for phantom rows

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -180,7 +180,22 @@ Missing fields fall back to defaults, so a v0.1.x pref file (just
 /island size   <small|medium|large|xlarge>
 /island screen <primary|active|2|3|...>
 /island notch  <auto|normal|notch>
+/island reset  | clear     — evict phantom rows (keeps companion alive)
+/island reload | restart   — respawn companion (heavier, re-reads pref file)
 ```
+
+**`reset` vs `reload`:** both recover from stuck "Working" rows left
+behind when a pi session died without sending its own `remove`
+(SIGKILL'd terminal, lost SSH, OS crash, …).
+- `reset` sends a `clear` socket message → companion calls
+  `window.island.removeAllRows()` → surviving sessions simply
+  re-upsert themselves on their next event. Cheap, no daemon restart.
+- `reload` goes through `respawnCompanion()` — full NSWindow close +
+  fresh process + pref reload. Slower but also recovers window-level
+  weirdness (wrong screen after monitor change, stuck notch mode, …).
+
+Helpers: `doReset` / `doReload` in `index.ts`. `sendClear` writes the
+new `{ type: "clear" }` socket message.
 
 **Removed in v0.2.0:** `/island2`. Its behaviour (force notch wrap)
 moved into the menu's `Notch wrap` row — and unlike the old command,
@@ -224,6 +239,11 @@ One JSON object per line. Writer: `writeMessage` in `index.ts`. Reader:
 
 // Size preset — flips the global --scale CSS var (live, no respawn)
 { "id": "...", "type": "scale",   "scale": "small" | "medium" | "large" | "xlarge" }
+
+// Wipe every row from the webview. Does NOT kick live sockets — they
+// simply re-upsert their row on the next event. Phantom rows (orphaned
+// by a crashed client) stay gone. Used by /island reset.
+{ "id": "...", "type": "clear" }
 
 // Graceful companion shutdown — client's next ensureConnection() spawns a
 // fresh instance that re-reads ~/.pi/pi-island.json (used for screen and

--- a/README.md
+++ b/README.md
@@ -51,10 +51,24 @@ Muscle memory / scripts:
 /island size large
 /island screen primary
 /island notch notch
+/island reset         # or: clear   — evict phantom rows, keep the companion alive
+/island reload        # or: restart — respawn the companion (heavier reset)
 ```
 
 Run pi in multiple terminals — each session gets its own row,
 stacked into one continuous capsule.
+
+### Stuck rows?
+
+If a pi terminal is force-quit (SIGKILL, crash, lost SSH, …) its row
+can stay "Working" forever because the cleanup message never shipped.
+
+- `/island reset`  → wipes every row; surviving sessions re-draw
+  themselves on the next event.
+- `/island reload` → fully respawns the companion daemon
+  (also recovers from window-level quirks after display changes).
+
+Both commands are also safe to run at any time as a quick refresh.
 
 ## Website
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-island",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "macOS Dynamic-Island-style status capsule for the pi coding agent. Shows what pi is doing in real time, at the very top of your screen — with native notch-wrap support for MacBooks.",
   "type": "module",
   "keywords": [

--- a/pi-extension/companion.mjs
+++ b/pi-extension/companion.mjs
@@ -14,6 +14,7 @@
 //   { "id": "<session-uuid>", "type": "remove" }
 //   { "id": "<session-uuid>", "type": "mode",    "mode":  "normal"|"notch" }
 //   { "id": "<session-uuid>", "type": "scale",   "scale": "small"|"medium"|"large" }
+//   { "id": "<session-uuid>", "type": "clear" }
 //   { "id": "<session-uuid>", "type": "respawn" }
 //
 // On startup the companion also reads ~/.pi/pi-island.json for settings it
@@ -24,6 +25,16 @@
 // When the last client disconnects we keep the window for 6s so a quick
 // reconnect (pi /new, /reload, etc.) doesn't flash the capsule closed,
 // then exit cleanly.
+//
+// `clear` vs `respawn` — both are "reset" hammers:
+//   • `clear`   is cheap: webview-only nuke of every row. Surviving
+//                clients simply re-upsert themselves on the next event.
+//                Use when phantom rows (SIGKILL'd sessions that never
+//                sent their `remove`) pile up.
+//   • `respawn` is a full daemon restart — closes the NSWindow, drops
+//                the socket, process.exit(0). The next client connection
+//                boots a fresh companion that re-reads the pref file
+//                (required for screen / notchMode changes).
 
 import { createServer } from "node:net";
 import { createInterface } from "node:readline";
@@ -223,6 +234,15 @@ const server = createServer((sock) => {
       // list so new sizes can land in index.ts + island.html.mjs without a
       // companion change.
       send(`window.island.setScale(${JSON.stringify(msg.scale)})`);
+      return;
+    }
+    if (msg.type === "clear") {
+      // Wipe every row from the webview. This does NOT drop connected
+      // sockets — live clients re-upsert themselves on their very next
+      // event (tool call, message update, etc.) so their own row
+      // reappears automatically. Dead clients' phantom rows are gone
+      // for good, which is the whole point.
+      send(`window.island.removeAllRows()`);
       return;
     }
     if (msg.type === "respawn") {

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -286,6 +286,17 @@ export default function (pi: ExtensionAPI) {
     writeMessage({ id: SESSION_ID, type: "remove" });
   }
 
+  // Ask the companion to evict EVERY row from the webview. Used by
+  // /island reset to clear phantom rows left behind when other pi
+  // sessions died without sending their own `remove` (SIGKILL'd
+  // terminal, OS reboot, lost socket, …). The current session's row
+  // is re-upserted immediately after so the user's own capsule doesn't
+  // flicker away.
+  async function sendClear() {
+    if (!sock) { if (!(await ensureConnection())) return; }
+    writeMessage({ id: SESSION_ID, type: "clear" });
+  }
+
   // Ask the companion to cleanly exit so the client's next event respawns
   // it with fresh pref values. Used for settings that need a new NSWindow
   // (screen position, notch mode) — NSWindow geometry is fixed after spawn.
@@ -339,6 +350,55 @@ export default function (pi: ExtensionAPI) {
     persistPref();
     await respawnCompanion();
     ctx.ui.notify(`Island notch wrap → ${next}`, "info");
+  }
+
+  // `/island reset` — lightweight phantom sweep.
+  //
+  // Sends a single `clear` message so the companion calls
+  // `window.island.removeAllRows()`. Any still-alive pi session will
+  // re-upsert its own row on the next tool / message event, so only the
+  // orphaned rows (SIGKILL'd terminals etc.) stay gone. We also re-send
+  // the current session's state right away so the user who typed the
+  // command sees their own row reappear immediately instead of waiting
+  // for the next agent tick.
+  async function doReset(ctx: any) {
+    if (!shownForSession) {
+      ctx.ui.notify("Island is disabled — nothing to reset", "info");
+      return;
+    }
+    if (!(await ensureConnection())) {
+      ctx.ui.notify("Couldn't reach the island companion", "error");
+      return;
+    }
+    await sendClear();
+    // Re-show our own row so the reset feels instant for the active session.
+    if (inAgent) {
+      await sendUpdate("thinking", "");
+    } else if (startedAt != null) {
+      // Between agent runs: replay the last "done" so the user sees their
+      // capsule briefly and the 5s retract timer (if any) was already set.
+      await sendUpdate("done", "");
+    }
+    ctx.ui.notify("Island reset — phantom rows cleared", "info");
+  }
+
+  // `/island reload` — full daemon restart.
+  //
+  // Same hammer as respawnCompanion() but user-initiated. Closes the
+  // NSWindow, drops the socket, spawns a fresh companion which re-reads
+  // `~/.pi/pi-island.json` and gets a clean slate of rows. Heavier than
+  // /island reset but also recovers from window-level weirdness (wrong
+  // screen, stuck notch mode, stale CSS, …). Other live pi sessions
+  // will reconnect on their next event.
+  async function doReload(ctx: any) {
+    await respawnCompanion();
+    // Re-upsert our row against the fresh companion so the user sees
+    // something right away. If !inAgent we skip — the next event will
+    // bring us back, same as a cold start.
+    if (shownForSession && inAgent) {
+      await sendUpdate("thinking", "");
+    }
+    ctx.ui.notify("Island reloaded — companion respawned", "info");
   }
 
   // ── Settings menu — same UX as pi's /settings ────────────────────────────
@@ -523,11 +583,13 @@ export default function (pi: ExtensionAPI) {
   //   /island size <preset>     → set scale (small | medium | large)
   //   /island screen <value>    → set screen (primary | active | 2 | 3 ...)
   //   /island notch <mode>      → set notch wrap (auto | normal | notch)
+  //   /island reset             → clear phantom rows (keeps companion alive)
+  //   /island reload            → respawn companion (heavier reset)
   //
   // Subcommands let power users / scripts skip the menu. With no args the
   // menu is the friendlier path — same UX as pi's own /settings.
   pi.registerCommand("island", {
-    description: "Open pi-island settings (or /island size|screen|notch <value>)",
+    description: "Open pi-island settings (or /island size|screen|notch <value> | reset | reload)",
     handler: async (args, ctx) => {
       const parts = String(args ?? "").trim().split(/\s+/).filter(Boolean);
       if (parts.length === 0) {
@@ -542,6 +604,11 @@ export default function (pi: ExtensionAPI) {
         if (shownForSession) await doDisable(ctx); else await doEnable(ctx);
         return;
       }
+
+      // Phantom-row sweep: webview-only, keeps companion alive.
+      if (sub === "reset" || sub === "clear") { await doReset(ctx);  return; }
+      // Full companion respawn: heavier, also recovers NSWindow-level issues.
+      if (sub === "reload" || sub === "restart") { await doReload(ctx); return; }
 
       if (sub === "size") {
         const next = parts[1]?.toLowerCase();
@@ -598,7 +665,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       ctx.ui.notify(
-        `Unknown subcommand "${sub}". Try: /island (menu)  or  /island size|screen|notch <value>`,
+        `Unknown subcommand "${sub}". Try: /island (menu)  or  /island size|screen|notch <value>  or  /island reset|reload`,
         "error",
       );
     },

--- a/pi-extension/island.html.mjs
+++ b/pi-extension/island.html.mjs
@@ -6,6 +6,7 @@
 // Node → webview API (called via win.send from the companion):
 //   window.island.upsertRow(id, data)   — create or update a row
 //   window.island.removeRow(id)         — fade out + remove a row
+//   window.island.removeAllRows()       — clear every row (phantom reset)
 //   window.island.setMode("normal"|"notch")
 //
 // `data` shape:
@@ -444,6 +445,16 @@ body.notch-mode .row:first-child .t-sub { display: none; }
     }, 340);
   }
 
+  // Nuke every row in one shot — used by /island reset to evict phantom
+  // rows left behind when a pi session died without sending its own
+  // remove (SIGKILL'd terminal, OS crash, lost socket, …). We reuse
+  // removeRow() per id so the fade-out transition still plays; `order`
+  // is snapshotted because removeRow mutates it via the setTimeout.
+  function removeAllRows() {
+    var ids = order.slice();
+    for (var i = 0; i < ids.length; i++) removeRow(ids[i]);
+  }
+
   function setMode(mode) {
     document.body.className = mode === 'notch' ? 'notch-mode' : '';
   }
@@ -457,6 +468,7 @@ body.notch-mode .row:first-child .t-sub { display: none; }
   window.island = {
     upsertRow: upsertRow,
     removeRow: removeRow,
+    removeAllRows: removeAllRows,
     setMode: setMode,
     setScale: setScale,
   };


### PR DESCRIPTION
## Problem

pi session SIGKILL'd → row stuck on `Working` forever. Cleanup msg never ships. Only fix today is `pkill` companion by hand.

## Fix

Two new subcommands:

- `/island reset` (alias `clear`) — webview-only nuke via new `clear` socket msg. Live sessions re-upsert on next event, phantoms stay gone. No daemon restart.
- `/island reload` (alias `restart`) — full companion respawn (reuses `respawnCompanion`). Heavier but also recovers NSWindow issues.

## Changes

- `island.html.mjs` — `window.island.removeAllRows()`
- `companion.mjs` — handle `{ type: 'clear' }`
- `index.ts` — `doReset` / `doReload` + dispatcher entries + `sendClear` helper
- Docs: README "Stuck rows?" section + AGENT.md protocol/command notes
- Version → 0.2.1